### PR TITLE
wp_cache_flush_site doesnt flush global groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Contributors: l3rady<br/>
 Donate link: [http://l3rady.com/donate][2]<br/>
 Tags: APC, object cache, backend, cache, performance, speed<br/>
 Requires at least: 3.3<br/>
-Tested up to: 4.2.2<br/>
-Stable tag: 1.1.2
+Tested up to: 4.2.4<br/>
+Stable tag: 1.1.3
 
 WordPress APC Object Cache Backend provides a persistent memory-based backend for the WordPress object cache.
 
@@ -40,6 +40,9 @@ Define `WP_APC_KEY_SALT` to something that is unique for each install (like an m
 
 ## Changelog ##
 
+### 1.1.3 ###
++ BUGFIX: Fix `wp_cache_flush_site()` to flush global groups [See][10]
+
 ### 1.1.2 ###
 + BUGFIX: Fix site cache key not saving in `_set_cache_version()` [See][9]
 
@@ -69,3 +72,4 @@ Define `WP_APC_KEY_SALT` to something that is unique for each install (like an m
 [7]: https://github.com/l3rady/WordPress-APC-Object-Cache/pull/1
 [8]: https://github.com/l3rady/WordPress-APC-Object-Cache/pull/7
 [9]: https://github.com/l3rady/WordPress-APC-Object-Cache/pull/9
+[10]: https://github.com/l3rady/WordPress-APC-Object-Cache/pull/10

--- a/object-cache.php
+++ b/object-cache.php
@@ -663,6 +663,11 @@ class WP_Object_Cache {
 			$sites = array( $this->blog_prefix );
 		}
 
+		// Add global groups (site 0) to be flushed.
+		if ( !in_array( 0, $sites ) ) {
+			$sites[] = 0;
+		}
+
 		foreach ( $sites as $site ) {
 			$version = $this->_get_site_cache_version( $site );
 			$version++;

--- a/object-cache.php
+++ b/object-cache.php
@@ -3,7 +3,7 @@
 Plugin Name: WordPress APC Object Cache Backend
 Plugin URI: https://github.com/l3rady/WordPress-APC-Object-Cache
 Description: APC backend for WordPress' Object Cache
-Version: 1.1.2
+Version: 1.1.3
 Author: Scott Cariss
 Author URI: http://l3rady.com
 */


### PR DESCRIPTION
wp_cache_flush_site() doesn't flush global groups. Global groups are ID' as group 0 and if you dont pass site ID's to the function it defaults to flush the current site ID which is usually 1.

I think that site ID 0 should always be processed as part of a site flush.
